### PR TITLE
Constraint event monad in Always

### DIFF
--- a/src/Bolson/Always.purs
+++ b/src/Bolson/Always.purs
@@ -5,14 +5,17 @@ import Prelude
 import Data.Monoid.Always (class Always, always)
 import Effect (Effect)
 import Heterogeneous.Mapping (class HMap, class Mapping, hmap)
+import Type.Equality (class TypeEquals)
+import Type.Proxy (Proxy)
 
-data AlwaysEffect = AlwaysEffect
+data AlwaysEffect (m :: Type -> Type) = AlwaysEffect (Proxy m)
 
 instance
-  ( Always (m Unit) (Effect Unit)
+  ( Always (m2 Unit) (Effect Unit)
+  , TypeEquals m1 m2
   ) =>
-  Mapping AlwaysEffect (i -> m Unit) (i -> Effect Unit) where
-  mapping AlwaysEffect = map always
+  Mapping (AlwaysEffect m1) (i -> m2 Unit) (i -> Effect Unit) where
+  mapping (AlwaysEffect _) = map always
 
-halways :: forall i o. HMap AlwaysEffect i o => i -> o
-halways = hmap AlwaysEffect
+halways :: forall m i o. HMap (AlwaysEffect m) i o => Proxy m -> i -> o
+halways p = hmap (AlwaysEffect p)


### PR DESCRIPTION
Prevents `m` from being unknown when it is not used. Downside of requiring a proxy argument to `halways` (there's no way to tell PS that it can be inferred from the record types).