### PR TITLE
Allow vbusses to be recursive

### DIFF
--- a/src/Bolson/Always.purs
+++ b/src/Bolson/Always.purs
@@ -17,5 +17,11 @@ instance
   Mapping (AlwaysEffect m1) (i -> m2 Unit) (i -> Effect Unit) where
   mapping (AlwaysEffect _) = map always
 
+instance
+  ( HMap (AlwaysEffect m) (Record i) (Record o)
+  ) =>
+  Mapping (AlwaysEffect m) (Record i) (Record o) where
+  mapping (AlwaysEffect p) = halways p
+
 halways :: forall m i o. HMap (AlwaysEffect m) i o => Proxy m -> i -> o
 halways p = hmap (AlwaysEffect p)


### PR DESCRIPTION
All the machinery is there for recursive vbusses, but Bolson got stuck when it encountered the record instead of the effect function.